### PR TITLE
Fix Dockerfile for last version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ RUN apk add -U git \
     && cd /go/src/github.com/evildecay/etcdkeeper \
     && go get github.com/golang/dep/... \
     && dep ensure -update \
-    && go build -o etcdkeeper.bin httpserver.go
+    && go build -o etcdkeeper.bin src/httpserver/httpserver.go
 
 FROM alpine:3.6
 
 WORKDIR /etcdkeeper
 COPY --from=builder /go/src/github.com/evildecay/etcdkeeper/etcdkeeper.bin .
-ADD etcdkeeper /etcdkeeper
+ADD assets assets
 
 CMD ./etcdkeeper.bin


### PR DESCRIPTION
The Dockerfile wasn't updated to the last version of the repository.

**Changes:**
- assets folder must be on the same path that etcdkeeper.bin executable
- source code is now in src/httpserver directory