### PR TITLE
Make container configurable through env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine as builder
+FROM golang:1.9-alpine as builder
 
 ADD . /go/src/github.com/evildecay/etcdkeeper
 
@@ -8,10 +8,16 @@ RUN apk add -U git \
     && dep ensure -update \
     && go build -o etcdkeeper.bin src/httpserver/httpserver.go
 
-FROM alpine:3.6
+FROM alpine:3.7
+
+ENV HOST="127.0.0.1"
+ENV PORT="8080"
+ENV NAME="request"
 
 WORKDIR /etcdkeeper
 COPY --from=builder /go/src/github.com/evildecay/etcdkeeper/etcdkeeper.bin .
 ADD assets assets
 
-CMD ./etcdkeeper.bin
+EXPOSE ${PORT}
+
+ENTRYPOINT ./etcdkeeper.bin -h $HOST -p $PORT -n $NAME


### PR DESCRIPTION
* Added three environment variables, HOST, PORT and NAME, that allows the user configure the service in a easy way
* Changed CMD to ENTRYPOINT
* Added -h, -p and -n parameters to the entrypoint
* Added EXPOSE instruction, allowing the use of `docker run -P ...` to expose the default port (8080)
* Updated to golang 1.9 and alpine 3.7