### PR TITLE
add baseurl & default_etcd options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM harbor.hxsf.work/library/golang:1.12-alpine3.10 as build
+FROM golang:1.12-alpine3.10 as build
 
 ENV GO111MODULE on
 ENV GOPROXY "https://goproxy.cn"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.12 as build
+FROM harbor.hxsf.work/library/golang:1.12-alpine3.10 as build
 
 ENV GO111MODULE on
-ENV GOPROXY "https://goproxy.io"
+ENV GOPROXY "https://goproxy.cn"
 
 WORKDIR /opt
 RUN mkdir etcdkeeper
@@ -27,4 +27,5 @@ ADD assets assets
 
 EXPOSE ${PORT}
 
-ENTRYPOINT ./etcdkeeper.bin -h $HOST -p $PORT
+ENTRYPOINT ["./etcdkeeper.bin"]
+CMD ["-h", "$HOST", "-p", "$PORT"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@
         use etcd auth
   -timeout int
         ETCD client connect timeout
+  -baseurl string
+        If you deploy etcdkeeper into a sub Dir
+  -default_etcd string
+        default etcd address, empty if do not want auto connect (default "127.0.0.1:2379")
+
 ```
 * Open your browser and enter the address: http://127.0.0.1:8080/etcdkeeper
 * Click on the version of the title to select the version of ETCD. The default is V3. Reopening will remember your choice.

--- a/assets/etcdkeeper/index.html
+++ b/assets/etcdkeeper/index.html
@@ -8,6 +8,7 @@
 	<link rel="stylesheet" type="text/css" href="../framework/easyui/themes/icon.css">
 	<link rel="stylesheet" type="text/css" href="../framework/custom/css/style.css">
 	<!-- 此行代码解决ie8中iframe里嵌套此页面会导致jquery错误-->
+	<script type="text/javascript" src="../vars.js"></script>
 	<script>document.documentElement.focus();</script>
 	<script type="text/javascript" src="../framework/easyui/jquery.min.js"></script>
 	<script type="text/javascript" src="../framework/easyui/jquery.easyui.min.js"></script>
@@ -32,7 +33,7 @@
 	<h2><img src="../framework/logo.png" width="20" style="position:relative;top:3px;"></img><font color="00a0e9"> ETCD</font> Keeper <span id="ver" style="border: 1px solid #D4D4D4;border-radius: 5px;cursor:pointer;">v3</span></h2>
 	<div class="noborder">
 		<img id="userButton" src="../framework/easyui/themes/icons/user.png" width="20" style="position:relative;top:7px;cursor:pointer;"></img>
-		<input id="etcdAddr" class="easyui-textbox" data-options="prompt:'127.0.0.1:2379',onChange:changeHost,iconCls:'icon-server',iconAlign:'left'" style="width:360px;height:30px;"/>
+		<input id="etcdAddr" class="easyui-textbox" data-options="prompt:'host:port',onChange:changeHost,iconCls:'icon-server',iconAlign:'left'" style="width:360px;height:30px;"/>
 	</div>
 	<div style="margin:20px 0;"></div>
 	<div id="elayout" class="easyui-layout" style="width:100%;height:550px;">
@@ -92,7 +93,7 @@
 			<div style="text-align:center;padding:5px">
 				<a href="javascript:void(0)" class="easyui-linkbutton" onclick="createNode()">Submit</a>
 			</div>
-	    </div>
+		</div>
 	</div>
 	
 	<div id="userinfo" class="easyui-window" title="Authentication" data-options="modal:true,closed:true" style="width:350px;height:220px;padding:10px;">
@@ -110,7 +111,7 @@
 			<div style="text-align:center;padding:5px">
 				<a href="javascript:void(0)" class="easyui-linkbutton" onclick="userOK()">Submit</a>
 			</div>
-	    </div>
+		</div>
 	</div>
 
 	<div style="text-align:right;color:#BDBDBD;margin-top:2px;">
@@ -131,10 +132,10 @@
 		<div id="mode_json" onclick="changeMode('json')">json</div>
 	</div>
 
-    <div id="versionMenu" class="easyui-menu">
-        <div id="version_3" onclick="selVersion('3')">version 3</div>
-        <div id="version_2" onclick="selVersion('2')">version 2</div>
-    </div>
+	<div id="versionMenu" class="easyui-menu">
+		<div id="version_3" onclick="selVersion('3')">version 3</div>
+		<div id="version_2" onclick="selVersion('2')">version 2</div>
+	</div>
 	
 	<script>
 		resizeWindow();
@@ -147,64 +148,69 @@
 		}
 
 		var timeout = 5000 // milliseconds
-		var separator = '';
-		var serverBase = '/v3';
+		var separator = separator || '';
+		var default_etcd = default_etcd || '';
+		var position = location.pathname.lastIndexOf('etcdkeeper')
+		var defaultRoot = position > -1 ? location.pathname.slice(0, position-1) : ''
+		var root_path = root_path || defaultRoot;
+
+		var serverBase = root_path + '/v3';
 		var etcdBase = Cookies.get('etcd-endpoint');
 		if(typeof(etcdBase) === 'undefined') {
-			etcdBase = '127.0.0.1:2379';
+			etcdBase = default_etcd;
 		}
 
-        // version switch
-        var version = Cookies.get('etcd-version');
-        if(typeof(version) === 'undefined') {
-            version = '3';
-        }
-        setServerBase(version);
-        $(function(){
-            $('#ver').bind('click',function(e){
-                e.preventDefault();
-                $('#versionMenu').menu('show', {
-                    left: e.pageX,
-                    top: e.pageY
-                });
-            });
+		// version switch
+		var version = Cookies.get('etcd-version');
+		if(typeof(version) === 'undefined') {
+			version = '3';
+		}
+		setServerBase(version);
+		$(function(){
+			$('#ver').bind('click',function(e){
+				e.preventDefault();
+				$('#versionMenu').menu('show', {
+					left: e.pageX,
+					top: e.pageY
+				});
+			});
 			$('#userButton').bind('click',function(e){
-                $('#userinfo').window('open');
-            });
-        });
-        function selVersion(ver) {
-            setServerBase(ver);
-            version = ver;
-            connect();
-            Cookies.set('etcd-version', version, {expires: 30});
+				$('#userinfo').window('open');
+			});
+		});
+		function selVersion(ver) {
+			setServerBase(ver);
+			version = ver;
+			connect();
+			Cookies.set('etcd-version', version, {expires: 30});
 
-            $('#versionMenu').menu('setIcon', {
-                target: $('#version_2')[0],
-                iconCls: ''
-            });
-            $('#versionMenu').menu('setIcon', {
-                target: $('#version_3')[0],
-                iconCls: ''
-            });
-            $('#versionMenu').menu('setIcon', {
-                target: $('#version_' + ver)[0],
-                iconCls: 'icon-ok'
-            });
-        }
-        function setServerBase(ver) {
-            if (ver === '3') {
-                $('#ver').html('v3');
-                serverBase = '/v3';
-            } else {
-                $('#ver').html('v2');
-                serverBase = '/v2';
-            }
-        }
+			$('#versionMenu').menu('setIcon', {
+				target: $('#version_2')[0],
+				iconCls: ''
+			});
+			$('#versionMenu').menu('setIcon', {
+				target: $('#version_3')[0],
+				iconCls: ''
+			});
+			$('#versionMenu').menu('setIcon', {
+				target: $('#version_' + ver)[0],
+				iconCls: 'icon-ok'
+			});
+		}
+		function setServerBase(ver) {
+			if (ver === '3') {
+				$('#ver').html('v3');
+				serverBase = root_path+'/v3';
+			} else {
+				$('#ver').html('v2');
+				serverBase = root_path+'/v2';
+			}
+		}
 
 		var tree = [];
 		var idCount = 0;
 		var editor = ace.edit('value');
-        editor.$blockScrolling = Infinity;
+		editor.$blockScrolling = Infinity;
 		var curIconMode = 'mode_icon_text';
 		var aceMode = Cookies.get('ace-mode');
 		if (typeof(aceMode) === 'undefined') {
@@ -215,38 +221,22 @@
 			treeMode = 'list';
 		}
 		if (version === '2') {
-		    treeMode = 'path'
+			treeMode = 'path'
 		}
 		//var autoFormat = Cookies.get('auto-format');
 		//if(typeof(autoFormat) === 'undefined') {
 			//autoFormat = 'false';
 		//}
 		
-		// get separator
-		$.ajax({
-			type: 'GET',
-			timeout: timeout,
-			url:  serverBase + '/separator',
-			async: false,
-			dataType: 'text',
-			success: function(data) {
-				separator = data;
-				console.log(data);
-			},
-			error: function(err) {
-				$.messager.alert('Error', $.toJSON(err), 'error');
-			}
-		});
-		
 		$(document).ready(function() {
 			editor.setTheme('ace/theme/github');
 			editor.getSession().setMode('ace/mode/' + aceMode);
 			changeMode(aceMode);
 			init();
-            $('#versionMenu').menu('setIcon', {
-                target: $('#version_' + version)[0],
-                iconCls: 'icon-ok'
-            });
+			$('#versionMenu').menu('setIcon', {
+				target: $('#version_' + version)[0],
+				iconCls: 'icon-ok'
+			});
 		});
 		
 		function init() {
@@ -270,7 +260,7 @@
 		}
 		
 		function connect() {
-			var status = 'ok';
+			if (!etcdBase) return
 			var uname = $('#uname').textbox('getValue');
 			var passwd = $('#passwd').textbox('getValue');
 			$.ajax({
@@ -278,23 +268,25 @@
 				timeout: timeout,
 				url:  serverBase + '/connect',
 				data: {'host': etcdBase, 'uname': uname, 'passwd': passwd},
-				async: false,
+				async: true,
 				dataType: 'json',
 				success: function(data) {
+					var status = 'ok';
 					if (data.status === 'ok') {
 						console.log('Connect etcd success.');
+						reload();
 						//alertMessage('Connect etcd success.');
 					} else if (data.status === 'running') {
 						console.log('Etcd is running.');
 					} else if (data.status === 'login') {
-						console.log('User login required.');
-						status = 'login';
+						$('#userinfo').window('open');
 					} else if (data.status === 'root') {
-						console.log('Need to set root.');
-						status = 'root';
+						$.messager.alert('Warning', 'The server needs to initialize the root user.');
+						$('#userinfo').window('open');
 					} else {
 						$.messager.alert('Error', data.message, 'error');
-						status = 'error';
+						resetValue();
+						$('#etree').tree('loadData', []);
 					}
 					if (data.info) {
 						$('#statusVersion').html('ETCD version:' + data.info.version);
@@ -310,18 +302,6 @@
 					$.messager.alert('Error', $.toJSON(err), 'error');
 				}
 			});
-			
-			if (status === 'ok') {
-				reload();
-			} else if (status === 'login') {
-				$('#userinfo').window('open');
-			} else if (status === 'root') {
-				$('#userinfo').window('open');
-				$.messager.alert('Warning', 'The server needs to initialize the root user.');
-			} else {
-				resetValue();
-				$('#etree').tree('loadData', []);
-			}
 		}
 		
 		function reload() {
@@ -390,7 +370,7 @@
 						return
 					}
 					editor.setReadOnly(true);
-                }
+				}
 
 				$('#footer').html('&nbsp;');
 				// clear child node
@@ -483,9 +463,9 @@
 			if (treeMode === 'path') {
 				mid = 'treeDirMenu';
 				if (version === '2') {
-                    if (node.dir !== true) {
-                        mid = "treeNodeMenu";
-                    }
+					if (node.dir !== true) {
+						mid = "treeNodeMenu";
+					}
 				}
 			} else {
 				if (node.dir === true) {
@@ -633,11 +613,11 @@
 										};
 									}
 									var objNode = nodeExist(obj.path);
-                                    if (objNode != null) {
-                                        node = objNode;
-                                        prePath = node.path;
-                                        continue;
-                                    }
+									if (objNode != null) {
+										node = objNode;
+										prePath = node.path;
+										continue;
+									}
 									if (newData.length === 0) {
 										newData.push(obj);
 									} else {
@@ -647,12 +627,12 @@
 									prePath = obj.path;
 								}
 								if (version === '3') {
-                                    $('#etree').tree('update', {
-                                        target: node.target,
-                                        iconCls: 'icon-dir'
-                                    });
+									$('#etree').tree('update', {
+										target: node.target,
+										iconCls: 'icon-dir'
+									});
 								}
-                                $('#etree').tree('append', {
+								$('#etree').tree('append', {
 									parent: node.target,
 									data: newData
 								});
@@ -701,13 +681,13 @@
 								$('#etree').tree('remove', node.target);
 
 								if (version === '3') {
-                                    var isLeaf = $('#etree').tree('isLeaf', pnode.target);
-                                    if (isLeaf && pnode.text !== separator) {
-                                        $('#etree').tree('update', {
-                                            target: pnode.target,
-                                            iconCls: 'icon-text'
-                                        });
-                                    }
+									var isLeaf = $('#etree').tree('isLeaf', pnode.target);
+									if (isLeaf && pnode.text !== separator) {
+										$('#etree').tree('update', {
+											target: pnode.target,
+											iconCls: 'icon-text'
+										});
+									}
 								}
 							} else {
 								$.messager.alert('Error', data, 'error');
@@ -771,17 +751,17 @@
 		}
 		
 		function changeTreeMode() {
-		    if (version === '2') {
-		        treeMode = 'path';
-                alertMessage('Etcd v2 only supports directory mode.');
+			if (version === '2') {
+				treeMode = 'path';
+				alertMessage('Etcd v2 only supports directory mode.');
 			} else {
-                if (treeMode === 'list') {
-                    treeMode = 'path';
-                } else {
-                    treeMode = 'list';
-                }
-                Cookies.set('tree-mode', treeMode, {expires: 30});
-                connect();
+				if (treeMode === 'list') {
+					treeMode = 'path';
+				} else {
+					treeMode = 'list';
+				}
+				Cookies.set('tree-mode', treeMode, {expires: 30});
+				connect();
 			}
 		}
 		

--- a/src/etcdkeeper/main.go
+++ b/src/etcdkeeper/main.go
@@ -8,9 +8,6 @@ import (
 	_ "etcdkeeper/session/providers/memory"
 	"flag"
 	"fmt"
-	"github.com/coreos/etcd/client"
-	"github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/pkg/transport"
 	"io"
 	"log"
 	"net/http"
@@ -21,16 +18,22 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/coreos/etcd/client"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
 )
 
 var (
 	sep            = flag.String("sep", "/", "separator")
+	basedir        = flag.String("baseurl", "", "If you deploy etcdkeeper into a sub Dir")
 	separator      = ""
 	usetls         = flag.Bool("usetls", false, "use tls")
 	cacert         = flag.String("cacert", "", "verify certificates of TLS-enabled secure servers using this CA bundle (v3)")
 	cert           = flag.String("cert", "", "identify secure client using this TLS certificate file (v3)")
 	keyfile        = flag.String("key", "", "identify secure client using this TLS key file (v3)")
 	useAuth        = flag.Bool("auth", false, "use auth")
+	default_etcd   = flag.String("default_etcd", "127.0.0.1:2379", "default etcd address")
 	connectTimeout = flag.Int("timeout", 5, "ETCD client connect timeout")
 	rootUsers      = make(map[string]*userInfo) // host:rootUser
 	rootUesrsV2    = make(map[string]*userInfo) // host:rootUser
@@ -46,11 +49,18 @@ type userInfo struct {
 }
 
 func main() {
-	host := flag.String("h","0.0.0.0","host name or ip address")
+	host := flag.String("h", "0.0.0.0", "host name or ip address")
 	port := flag.Int("p", 8080, "port")
 
 	flag.CommandLine.Parse(os.Args[1:])
 	separator = *sep
+
+	if *basedir != "" && (*basedir)[0] != '/' {
+		log.Fatal("baseDir must be empty or start with `/`")
+	}
+	if len(*basedir) > 0 {
+		*basedir = strings.TrimRight(*basedir, "/")
+	}
 
 	middleware := func(fns ...func(w http.ResponseWriter, r *http.Request)) func(w http.ResponseWriter, r *http.Request) {
 		return func(w http.ResponseWriter, r *http.Request) {
@@ -60,24 +70,24 @@ func main() {
 		}
 	}
 
+	http.HandleFunc(*basedir+"/vars.js", middleware(nothing, getConfig))
+
 	// v2
 	//http.HandleFunc(*name, v2request)
-	http.HandleFunc("/v2/separator", middleware(nothing, getSeparator))
-	http.HandleFunc("/v2/connect", middleware(nothing, connectV2))
-	http.HandleFunc("/v2/put", middleware(nothing, putV2))
-	http.HandleFunc("/v2/get", middleware(nothing, getV2))
-	http.HandleFunc("/v2/delete", middleware(nothing, delV2))
+	http.HandleFunc(*basedir+"/v2/connect", middleware(nothing, connectV2))
+	http.HandleFunc(*basedir+"/v2/put", middleware(nothing, putV2))
+	http.HandleFunc(*basedir+"/v2/get", middleware(nothing, getV2))
+	http.HandleFunc(*basedir+"/v2/delete", middleware(nothing, delV2))
 	// dirctory mode
-	http.HandleFunc("/v2/getpath", middleware(nothing, getPathV2))
+	http.HandleFunc(*basedir+"/v2/getpath", middleware(nothing, getPathV2))
 
 	// v3
-	http.HandleFunc("/v3/separator", middleware(nothing, getSeparator))
-	http.HandleFunc("/v3/connect", middleware(nothing, connect))
-	http.HandleFunc("/v3/put", middleware(nothing, put))
-	http.HandleFunc("/v3/get", middleware(nothing, get))
-	http.HandleFunc("/v3/delete", middleware(nothing, del))
+	http.HandleFunc(*basedir+"/v3/connect", middleware(nothing, connect))
+	http.HandleFunc(*basedir+"/v3/put", middleware(nothing, put))
+	http.HandleFunc(*basedir+"/v3/get", middleware(nothing, get))
+	http.HandleFunc(*basedir+"/v3/delete", middleware(nothing, del))
 	// dirctory mode
-	http.HandleFunc("/v3/getpath", middleware(nothing, getPath))
+	http.HandleFunc(*basedir+"/v3/getpath", middleware(nothing, getPath))
 
 	wd, err := os.Executable()
 	if err != nil {
@@ -93,12 +103,13 @@ func main() {
 	time.AfterFunc(86400*time.Second, func() {
 		sessmgr.GC()
 	})
-	//log.Println(http.Dir(rootPath + "/assets"))
+	log.Println("static file serve:", *basedir+"/ ->", http.Dir(rootPath+"/assets"))
+	log.Println("default_etcd:", *default_etcd)
 
-	http.Handle("/", http.FileServer(http.Dir(rootPath + "/assets"))) // view static directory
+	http.Handle(*basedir+"/", http.StripPrefix(*basedir+"/", http.FileServer(http.Dir(rootPath+"/assets")))) // view static directory
 
-	log.Printf("listening on %s:%d\n", *host, *port)
-	err = http.ListenAndServe(*host + ":" + strconv.Itoa(*port), nil)
+	log.Printf("listening on http://%s:%d%s/\n", *host, *port, *basedir)
+	err = http.ListenAndServe(*host+":"+strconv.Itoa(*port), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -107,7 +118,6 @@ func main() {
 func nothing(_ http.ResponseWriter, _ *http.Request) {
 	// Nothing
 }
-
 
 //func v2request(w http.ResponseWriter, r *http.Request){
 //	if err := r.ParseForm(); err != nil {
@@ -136,6 +146,12 @@ func nothing(_ http.ResponseWriter, _ *http.Request) {
 //	}
 //}
 
+func getConfig(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/javascript")
+	w.WriteHeader(200)
+	_, _ = w.Write([]byte(fmt.Sprintf("var separator = '%s';\nvar root_path = '%s';\nvar default_etcd = '%s';\n", separator, *basedir, *default_etcd)))
+}
+
 // v2 api
 func connectV2(w http.ResponseWriter, r *http.Request) {
 	mu.Lock()
@@ -151,12 +167,12 @@ func connectV2(w http.ResponseWriter, r *http.Request) {
 	if *useAuth {
 		_, ok := rootUesrsV2[host]
 		if !ok && uname != "root" {
-			b, _ := json.Marshal(map[string]interface{}{"status":"root"})
+			b, _ := json.Marshal(map[string]interface{}{"status": "root"})
 			io.WriteString(w, string(b))
 			return
 		}
 		if uname == "" || passwd == "" {
-			b, _ := json.Marshal(map[string]interface{}{"status":"login"})
+			b, _ := json.Marshal(map[string]interface{}{"status": "login"})
 			io.WriteString(w, string(b))
 			return
 		}
@@ -165,17 +181,17 @@ func connectV2(w http.ResponseWriter, r *http.Request) {
 	if uinfo, ok := sess.Get("uinfov2").(*userInfo); ok {
 		if host == uinfo.host && uname == uinfo.uname && passwd == uinfo.passwd {
 			info := getInfoV2(host)
-			b, _ := json.Marshal(map[string]interface{}{"status":"running", "info":info})
+			b, _ := json.Marshal(map[string]interface{}{"status": "running", "info": info})
 			io.WriteString(w, string(b))
 			return
 		}
 	}
 
-	uinfo := &userInfo{host:host, uname:uname, passwd:passwd}
+	uinfo := &userInfo{host: host, uname: uname, passwd: passwd}
 	_, err := newClientV2(uinfo)
 	if err != nil {
 		log.Println(r.Method, "v2", "connect fail.")
-		b, _ := json.Marshal(map[string]interface{}{"status":"error", "message":err.Error()})
+		b, _ := json.Marshal(map[string]interface{}{"status": "error", "message": err.Error()})
 		io.WriteString(w, string(b))
 		return
 	}
@@ -190,7 +206,7 @@ func connectV2(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Println(r.Method, "v2", "connect success.")
 	info := getInfoV2(host)
-	b, _ := json.Marshal(map[string]interface{}{"status":"running", "info":info})
+	b, _ := json.Marshal(map[string]interface{}{"status": "running", "info": info})
 	io.WriteString(w, string(b))
 }
 
@@ -215,15 +231,15 @@ func putV2(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			log.Println(err.Error())
 		}
-		_, err = kapi.Set(context.Background(), key, value, &client.SetOptions{TTL:time.Duration(sec)*time.Second, Dir:isDir})
+		_, err = kapi.Set(context.Background(), key, value, &client.SetOptions{TTL: time.Duration(sec) * time.Second, Dir: isDir})
 	} else {
-		_, err = kapi.Set(context.Background(), key, value, &client.SetOptions{Dir:isDir})
+		_, err = kapi.Set(context.Background(), key, value, &client.SetOptions{Dir: isDir})
 	}
 	if err != nil {
 		data["errorCode"] = 500
 		data["message"] = err.Error()
 	} else {
-		if resp, err := kapi.Get(context.Background(), key, &client.GetOptions{Recursive:true, Sort:true}); err != nil {
+		if resp, err := kapi.Get(context.Background(), key, &client.GetOptions{Recursive: true, Sort: true}); err != nil {
 			data["errorCode"] = err.Error()
 		} else {
 			if resp.Node != nil {
@@ -240,7 +256,7 @@ func putV2(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var dataByte []byte
-	if dataByte, err = json.Marshal(data);err != nil {
+	if dataByte, err = json.Marshal(data); err != nil {
 		io.WriteString(w, err.Error())
 	} else {
 		io.WriteString(w, string(dataByte))
@@ -284,7 +300,7 @@ func getV2(w http.ResponseWriter, r *http.Request) {
 		max = min
 		all := make(map[int][]map[string]interface{})
 		if key == separator {
-			all[min] = []map[string]interface{}{{"key":key, "value":"", "dir":true, "nodes":make([]map[string]interface{}, 0)}}
+			all[min] = []map[string]interface{}{{"key": key, "value": "", "dir": true, "nodes": make([]map[string]interface{}, 0)}}
 		}
 		for _, p := range permissions {
 			pKey, pRange := p[0], p[1]
@@ -293,7 +309,7 @@ func getV2(w http.ResponseWriter, r *http.Request) {
 				if pRange == "c" {
 					pKey += separator
 				}
-				opt = &client.GetOptions{Recursive:true, Sort:true}
+				opt = &client.GetOptions{Recursive: true, Sort: true}
 			}
 			if resp, err := kapi.Get(context.Background(), pKey, opt); err != nil {
 				data["errorCode"] = 500
@@ -303,7 +319,7 @@ func getV2(w http.ResponseWriter, r *http.Request) {
 					data["errorCode"] = 500
 					data["message"] = "The node does not exist."
 				} else {
-					max = getNode(resp.Node , key, all, min, max)
+					max = getNode(resp.Node, key, all, min, max)
 				}
 			}
 		}
@@ -319,7 +335,7 @@ func getV2(w http.ResponseWriter, r *http.Request) {
 						pa["nodes"] = append(pa["nodes"].([]map[string]interface{}), a)
 						pa["dir"] = true
 					} else {
-						if strings.HasPrefix(a["key"].(string), pa["key"].(string) + separator) {
+						if strings.HasPrefix(a["key"].(string), pa["key"].(string)+separator) {
 							pa["nodes"] = append(pa["nodes"].([]map[string]interface{}), a)
 							pa["dir"] = true
 						}
@@ -339,7 +355,7 @@ func getV2(w http.ResponseWriter, r *http.Request) {
 
 	var dataByte []byte
 	var err error
-	if dataByte, err = json.Marshal(data);err != nil {
+	if dataByte, err = json.Marshal(data); err != nil {
 		io.WriteString(w, err.Error())
 	} else {
 		io.WriteString(w, string(dataByte))
@@ -350,7 +366,7 @@ func nodesSort(node map[string]interface{}) {
 	if v, ok := node["nodes"]; ok && v != nil {
 		a := v.([]map[string]interface{})
 		if len(a) != 0 {
-			for i := 0; i < len(a) - 1; i++ {
+			for i := 0; i < len(a)-1; i++ {
 				nodesSort(a[i])
 				for j := i + 1; j < len(a); j++ {
 					if a[j]["key"].(string) < a[i]["key"].(string) {
@@ -358,7 +374,7 @@ func nodesSort(node map[string]interface{}) {
 					}
 				}
 			}
-			nodesSort(a[len(a) - 1])
+			nodesSort(a[len(a)-1])
 		}
 	}
 }
@@ -373,7 +389,7 @@ func getNode(node *client.Node, selKey string, all map[int][]map[string]interfac
 		if k == "" {
 			continue
 		}
-		nodeMap := map[string]interface{}{"key": k, "dir":true, "nodes":make([]map[string]interface{}, 0)}
+		nodeMap := map[string]interface{}{"key": k, "dir": true, "nodes": make([]map[string]interface{}, 0)}
 		if k == node.Key {
 			nodeMap["value"] = node.Value
 			nodeMap["dir"] = node.Dir
@@ -386,7 +402,7 @@ func getNode(node *client.Node, selKey string, all map[int][]map[string]interfac
 			max = keylevel
 		}
 
-		if _, ok := all[keylevel];!ok {
+		if _, ok := all[keylevel]; !ok {
 			all[keylevel] = make([]map[string]interface{}, 0)
 		}
 		var isExist bool
@@ -417,7 +433,7 @@ func delV2(w http.ResponseWriter, r *http.Request) {
 
 	isDir, _ := strconv.ParseBool(dir)
 	if isDir {
-		if _, err := kapi.Delete(context.Background(), key, &client.DeleteOptions{Recursive:true, Dir:true}); err != nil {
+		if _, err := kapi.Delete(context.Background(), key, &client.DeleteOptions{Recursive: true, Dir: true}); err != nil {
 			io.WriteString(w, err.Error())
 			return
 		}
@@ -501,10 +517,10 @@ func getPermissionPrefixV2(host, uname, key string) ([][]string, error) {
 						for _, ks := range role.Permissions.KV.Read {
 							var k string
 							if strings.HasSuffix(ks, "*") {
-								k = ks[:len(ks) - 1]
+								k = ks[:len(ks)-1]
 								set[k] = "p"
 							} else if strings.HasSuffix(ks, "/*") {
-								k = ks[:len(ks) - 2]
+								k = ks[:len(ks)-2]
 								set[k] = "c"
 							} else {
 								if _, ok := set[ks]; !ok {
@@ -569,12 +585,12 @@ func connect(w http.ResponseWriter, r *http.Request) {
 
 	if *useAuth {
 		if _, ok := rootUsers[host]; !ok && uname != "root" { // no root user
-			b, _ := json.Marshal(map[string]interface{}{"status":"root"})
+			b, _ := json.Marshal(map[string]interface{}{"status": "root"})
 			io.WriteString(w, string(b))
 			return
 		}
 		if uname == "" || passwd == "" {
-			b, _ := json.Marshal(map[string]interface{}{"status":"login"})
+			b, _ := json.Marshal(map[string]interface{}{"status": "login"})
 			io.WriteString(w, string(b))
 			return
 		}
@@ -583,17 +599,17 @@ func connect(w http.ResponseWriter, r *http.Request) {
 	if uinfo, ok := sess.Get("uinfo").(*userInfo); ok {
 		if host == uinfo.host && uname == uinfo.uname && passwd == uinfo.passwd {
 			info := getInfo(host)
-			b, _ := json.Marshal(map[string]interface{}{"status":"running", "info":info})
+			b, _ := json.Marshal(map[string]interface{}{"status": "running", "info": info})
 			io.WriteString(w, string(b))
 			return
 		}
 	}
 
-	uinfo := &userInfo{host:host, uname:uname, passwd:passwd}
+	uinfo := &userInfo{host: host, uname: uname, passwd: passwd}
 	c, err := newClient(uinfo)
 	if err != nil {
 		log.Println(r.Method, "v3", "connect fail.")
-		b, _ := json.Marshal(map[string]interface{}{"status":"error", "message":err.Error()})
+		b, _ := json.Marshal(map[string]interface{}{"status": "error", "message": err.Error()})
 		io.WriteString(w, string(b))
 		return
 	}
@@ -609,7 +625,7 @@ func connect(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Println(r.Method, "v3", "connect success.")
 	info := getInfo(host)
-	b, _ := json.Marshal(map[string]interface{}{"status":"running", "info":info})
+	b, _ := json.Marshal(map[string]interface{}{"status": "running", "info": info})
 	io.WriteString(w, string(b))
 }
 
@@ -641,7 +657,7 @@ func put(w http.ResponseWriter, r *http.Request) {
 		data["errorCode"] = 500
 		data["message"] = err.Error()
 	} else {
-		if resp, err := cli.Get(context.Background(), key);err != nil {
+		if resp, err := cli.Get(context.Background(), key); err != nil {
 			data["errorCode"] = 500
 			data["errorCode"] = err.Error()
 		} else {
@@ -660,7 +676,7 @@ func put(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var dataByte []byte
-	if dataByte, err = json.Marshal(data);err != nil {
+	if dataByte, err = json.Marshal(data); err != nil {
 		io.WriteString(w, err.Error())
 	} else {
 		io.WriteString(w, string(dataByte))
@@ -727,7 +743,7 @@ func get(w http.ResponseWriter, r *http.Request) {
 			}
 			data["node"] = pnode
 		} else {
-			if resp, err := cli.Get(context.Background(), key);err != nil {
+			if resp, err := cli.Get(context.Background(), key); err != nil {
 				data["errorCode"] = 500
 				data["message"] = err.Error()
 			} else {
@@ -751,7 +767,7 @@ func get(w http.ResponseWriter, r *http.Request) {
 
 	var dataByte []byte
 	var err error
-	if dataByte, err = json.Marshal(data);err != nil {
+	if dataByte, err = json.Marshal(data); err != nil {
 		io.WriteString(w, err.Error())
 	} else {
 		io.WriteString(w, string(dataByte))
@@ -765,7 +781,7 @@ func getPath(w http.ResponseWriter, r *http.Request) {
 		data = make(map[string]interface{})
 		/*
 			{1:["/"], 2:["/foo", "/foo2"], 3:["/foo/bar", "/foo2/bar"], 4:["/foo/bar/test"]}
-		 */
+		*/
 		all = make(map[int][]map[string]interface{})
 		min int
 		max int
@@ -810,7 +826,7 @@ func getPath(w http.ResponseWriter, r *http.Request) {
 			//prefixKey = originKey
 		}
 		max = min
-		all[min] = []map[string]interface{}{{"key":originKey}}
+		all[min] = []map[string]interface{}{{"key": originKey}}
 		if presp != nil && presp.Count != 0 {
 			all[min][0]["value"] = string(presp.Kvs[0].Value)
 			all[min][0]["ttl"] = getTTL(cli, presp.Kvs[0].Lease)
@@ -841,12 +857,12 @@ func getPath(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				keys := strings.Split(string(kv.Key), separator) // /foo/bar
-				for i := range keys { // ["", "foo", "bar"]
+				for i := range keys {                            // ["", "foo", "bar"]
 					k := strings.Join(keys[0:i+1], separator)
 					if k == "" {
 						continue
 					}
-					node := map[string]interface{}{"key":k}
+					node := map[string]interface{}{"key": k}
 					if node["key"].(string) == string(kv.Key) {
 						node["value"] = string(kv.Value)
 						if key == string(kv.Key) {
@@ -862,7 +878,7 @@ func getPath(w http.ResponseWriter, r *http.Request) {
 						max = level
 					}
 
-					if _, ok := all[level];!ok {
+					if _, ok := all[level]; !ok {
 						all[level] = make([]map[string]interface{}, 0)
 					}
 					levelNodes := all[level]
@@ -888,7 +904,7 @@ func getPath(w http.ResponseWriter, r *http.Request) {
 						pa["nodes"] = append(pa["nodes"].([]map[string]interface{}), a)
 						pa["dir"] = true
 					} else {
-						if strings.HasPrefix(a["key"].(string), pa["key"].(string) +separator) {
+						if strings.HasPrefix(a["key"].(string), pa["key"].(string)+separator) {
 							pa["nodes"] = append(pa["nodes"].([]map[string]interface{}), a)
 							pa["dir"] = true
 						}
@@ -898,7 +914,7 @@ func getPath(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	data = all[min][0]
-	if dataByte, err := json.Marshal(map[string]interface{}{"node":data});err != nil {
+	if dataByte, err := json.Marshal(map[string]interface{}{"node": data}); err != nil {
 		io.WriteString(w, err.Error())
 	} else {
 		io.WriteString(w, string(dataByte))
@@ -912,13 +928,13 @@ func del(w http.ResponseWriter, r *http.Request) {
 	dir := r.FormValue("dir")
 	log.Println("DELETE", "v3", key)
 
-	if _, err := cli.Delete(context.Background(), key);err != nil {
+	if _, err := cli.Delete(context.Background(), key); err != nil {
 		io.WriteString(w, err.Error())
 		return
 	}
 
 	if dir == "true" {
-		if _, err := cli.Delete(context.Background(), key +separator, clientv3.WithPrefix());err != nil {
+		if _, err := cli.Delete(context.Background(), key+separator, clientv3.WithPrefix()); err != nil {
 			io.WriteString(w, err.Error())
 			return
 		}
@@ -935,10 +951,6 @@ func getTTL(cli *clientv3.Client, lease int64) int64 {
 		return 0
 	}
 	return resp.TTL
-}
-
-func getSeparator(w http.ResponseWriter, _ *http.Request) {
-	io.WriteString(w, separator)
 }
 
 func getClient(w http.ResponseWriter, r *http.Request) *clientv3.Client {
@@ -971,9 +983,9 @@ func newClient(uinfo *userInfo) (*clientv3.Client, error) {
 	}
 
 	conf := clientv3.Config{
-		Endpoints:            endpoints,
-		DialTimeout:          time.Second * time.Duration(*connectTimeout),
-		TLS:                  tlsConfig,
+		Endpoints:   endpoints,
+		DialTimeout: time.Second * time.Duration(*connectTimeout),
+		TLS:         tlsConfig,
 	}
 	if *useAuth {
 		conf.Username = uinfo.uname
@@ -1053,8 +1065,8 @@ func getInfo(host string) map[string]string {
 		log.Fatal(err)
 	}
 	kb := 1024
-	mb := kb*1024
-	gb := mb*1024
+	mb := kb * 1024
+	gb := mb * 1024
 	var sizeStr string
 	for _, m := range mems.Members {
 		if m.ID == status.Leader {
@@ -1086,5 +1098,5 @@ func getInfo(host string) map[string]string {
 }
 
 func size(num int, unit int) (n, rem int) {
-	return num/unit, num - (num/unit)*unit
+	return num / unit, num - (num/unit)*unit
 }

--- a/src/etcdkeeper/main.go
+++ b/src/etcdkeeper/main.go
@@ -33,7 +33,7 @@ var (
 	cert           = flag.String("cert", "", "identify secure client using this TLS certificate file (v3)")
 	keyfile        = flag.String("key", "", "identify secure client using this TLS key file (v3)")
 	useAuth        = flag.Bool("auth", false, "use auth")
-	default_etcd   = flag.String("default_etcd", "127.0.0.1:2379", "default etcd address")
+	default_etcd   = flag.String("default_etcd", "127.0.0.1:2379", "default etcd address, empty if do not want auto connect")
 	connectTimeout = flag.Int("timeout", 5, "ETCD client connect timeout")
 	rootUsers      = make(map[string]*userInfo) // host:rootUser
 	rootUesrsV2    = make(map[string]*userInfo) // host:rootUser


### PR DESCRIPTION
## arg: baseurl

make this app can deploy into a subpath, such as `example.com/tools/etcdkeeper`

## arg: default_etcd

if the app is used to connect etcd in other host, auto connect to 127.0.0.1:2379 will be timeout.

## feature: add `/vars.js` api to send config to frontend by js.

so it will not use ajax to get config.

## feature: connect will be async
I make `connect` async, so it will not hangup the browser. and `-default_etcd=""` args will make it not auto connect any etcd server.