### PR TITLE
fix: fix connect happen in background returning the client object before initial connect

### DIFF
--- a/src/etcdkeeper/main.go
+++ b/src/etcdkeeper/main.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -974,6 +975,7 @@ func newClient(uinfo *userInfo) (*clientv3.Client, error) {
 		Endpoints:            endpoints,
 		DialTimeout:          time.Second * time.Duration(*connectTimeout),
 		TLS:                  tlsConfig,
+		DialOptions: []grpc.DialOption{grpc.WithBlock()},
 	}
 	if *useAuth {
 		conf.Username = uinfo.uname
@@ -1043,6 +1045,7 @@ func getInfo(host string) map[string]string {
 		return info
 	}
 	defer rootClient.Close()
+
 
 	status, err := rootClient.Status(context.Background(), host)
 	if err != nil {


### PR DESCRIPTION
see https://github.com/etcd-io/etcd/issues/9877

new etcd client will connect happen in background returning the client object before initial connect.