### PR TITLE
support nginx reverse proxy: /subpath/etcdkeeper/

### DIFF
--- a/assets/etcdkeeper/index.html
+++ b/assets/etcdkeeper/index.html
@@ -148,7 +148,7 @@
 
 		var timeout = 5000 // milliseconds
 		var separator = '';
-		var serverBase = '/v3';
+		var serverBase = '../v3';
 		var etcdBase = Cookies.get('etcd-endpoint');
 		if(typeof(etcdBase) === 'undefined') {
 			etcdBase = '127.0.0.1:2379';
@@ -194,10 +194,10 @@
         function setServerBase(ver) {
             if (ver === '3') {
                 $('#ver').html('v3');
-                serverBase = '/v3';
+                serverBase = '../v3';
             } else {
                 $('#ver').html('v2');
-                serverBase = '/v2';
+                serverBase = '../v2';
             }
         }
 


### PR DESCRIPTION
support nginx reverse proxy make things better:

    nginx: /cluster1/etcdkeeper/    ->    http://cluster1_ip:8080/etcdkeeper/
    nginx: /cluster2/etcdkeeper/    ->    http://cluster2_ip:8080/etcdkeeper/
    ......

optionly, I can make it readonly for etcd viewer:
In nginx.conf:

    limit_except GET POST { deny all; } 

It test ok for me.  and I had use it for a while.