### PR TITLE
Update from hadolint scan suggestions:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOPROXY "https://goproxy.io"
 
 WORKDIR /opt
 RUN mkdir etcdkeeper
-ADD . /opt/etcdkeeper
+COPY . /opt/etcdkeeper
 WORKDIR /opt/etcdkeeper/src/etcdkeeper
 
 RUN go mod download \
@@ -23,8 +23,8 @@ RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
 WORKDIR /opt/etcdkeeper
 COPY --from=build /opt/etcdkeeper/src/etcdkeeper/etcdkeeper.bin .
-ADD assets assets
+COPY assets assets
 
 EXPOSE ${PORT}
 
-ENTRYPOINT ./etcdkeeper.bin -h $HOST -p $PORT
+ENTRYPOINT ["./etcdkeeper.bin", "-h", "$HOST", "-p", "$PORT"]


### PR DESCRIPTION
Use COPY instead of ADD
Use json-type args for ENTRYPOINT

My company does automated scans with hadolint. It identified these changes and I thought I would upstream this. Thanks.