### PR TITLE
[FIX]: Dockerfile env variable error, replace entrypoint with cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY assets assets
 
 EXPOSE ${PORT}
 
-ENTRYPOINT ["./etcdkeeper.bin", "-h", "$HOST", "-p", "$PORT"]
+CMD ./etcdkeeper.bin -h $HOST -p $PORT


### PR DESCRIPTION
1. Fixed argument passing issue
2. Replace entrypoint with cmd in Dockerfile to overwrite arguments
